### PR TITLE
Add Docker Compose Setup for Lazy Indexer and Opencast

### DIFF
--- a/.env.dev.sample
+++ b/.env.dev.sample
@@ -1,0 +1,34 @@
+## Indexer DB
+DATABASE_URL="postgres://replicator:password@localhost:6541/replicator?schema=public"
+
+## Farcaster Hub (optional: only required for writing)
+# The format is <host>:<port>, do not include the protocol
+FC_HUB_URL="hub-grpc.pinata.cloud"
+# If using the hub monorepo this should be set to false unless you setup TLS
+FC_HUB_USE_TLS="true"
+
+## App signer (required for registering new app signer keys)
+# Use your personal mnemonic for running locally
+APP_FID=
+APP_MNENOMIC=
+
+# RPC URLs (optional: public RPCs are used by default, but get rate limited)
+# These are used for fetching data from the blockchain
+# Format: CHAIN_RPC_URL_<CHAIN_ID>=<URL>
+CHAIN_RPC_URL_1=
+
+# Client name (only used for frontend aesthetics)
+NEXT_PUBLIC_FC_CLIENT_NAME="Opencast"
+
+## Imgur for image uploads (see https://apidocs.imgur.com)
+NEXT_PUBLIC_IMGUR_CLIENT_ID=
+IMGUR_CLIENT_SECRET=
+
+# WalletConnectV2 Id (you can get your own @ https://walletconnect.com/)
+NEXT_PUBLIC_WALLETCONNECT_ID=
+
+# Application URL (used for redirects)
+NEXT_PUBLIC_URL=http://localhost:3000
+
+# Indexer API for indexing progress
+INDEXER_API_URL=http://localhost:3005

--- a/.env.sample
+++ b/.env.sample
@@ -3,9 +3,9 @@ DATABASE_URL="postgres://replicator:password@localhost:6541/replicator?schema=pu
 
 ## Farcaster Hub (optional: only required for writing)
 # The format is <host>:<port>, do not include the protocol
-FC_HUB_URL="localhost:2283"
+FC_HUB_URL="hub-grpc.pinata.cloud"
 # If using the hub monorepo this should be set to false unless you setup TLS
-FC_HUB_USE_TLS="false"
+FC_HUB_USE_TLS="true"
 
 ## App signer (required for registering new app signer keys)
 # Use your personal mnemonic for running locally

--- a/.env.sample
+++ b/.env.sample
@@ -1,34 +1,11 @@
-## Indexer DB
-DATABASE_URL="postgres://replicator:password@localhost:6541/replicator?schema=public"
+# The indexer will listen for signers approved by this FID
+TARGET_SIGNER_FID="18821"
 
-## Farcaster Hub (optional: only required for writing)
-# The format is <host>:<port>, do not include the protocol
-FC_HUB_URL="hub-grpc.pinata.cloud"
-# If using the hub monorepo this should be set to false unless you setup TLS
-FC_HUB_USE_TLS="true"
+# Opencast will approve signers with this FID
+APP_FID="18821"
 
-## App signer (required for registering new app signer keys)
-# Use your personal mnemonic for running locally
-APP_FID=
-APP_MNENOMIC=
+# The mnemonic (seed phrase) of the wallet holds the APP_FID. This is the seed phrase given to you by warpcast
+APP_MNENOMIC=""
 
-# RPC URLs (optional: public RPCs are used by default, but get rate limited)
-# These are used for fetching data from the blockchain
-# Format: CHAIN_RPC_URL_<CHAIN_ID>=<URL>
-CHAIN_RPC_URL_1=
-
-# Client name (only used for frontend aesthetics)
-NEXT_PUBLIC_FC_CLIENT_NAME="Opencast"
-
-## Imgur for image uploads (see https://apidocs.imgur.com)
-NEXT_PUBLIC_IMGUR_CLIENT_ID=
-IMGUR_CLIENT_SECRET=
-
-# WalletConnectV2 Id (you can get your own @ https://walletconnect.com/)
-NEXT_PUBLIC_WALLETCONNECT_ID=
-
-# Application URL (used for redirects)
-NEXT_PUBLIC_URL=http://localhost:3000
-
-# Indexer API for indexing progress
-INDEXER_API_URL=http://localhost:3005
+# WalletConnect project id (https://cloud.walletconnect.com)
+NEXT_PUBLIC_WALLETCONNECT_ID="0fcda49e9f4acad4b84401373fbc5a4f"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # Use the official Node.js image.
 FROM node:20
 
-# Install necessary build tools
-RUN apk add python3 make g++ gcc
-
 # Set the working directory inside the container.
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,26 @@
 # Use the official Node.js image.
-FROM node:18-alpine
+FROM node:20
+
+# Install necessary build tools
+RUN apk add python3 make g++ gcc
 
 # Set the working directory inside the container.
 WORKDIR /app
 
 # Copy the package.json and yarn.lock files.
-COPY package*.json ./
+COPY package.json yarn.lock* ./
 
 # Install dependencies.
-RUN yarn install
-
-RUN apk add --no-cache python3 make g++ gcc
-
+RUN yarn install --frozen-lockfile
 
 # Copy the rest of the application code.
 COPY . .
 
+# Generate Prisma client
+RUN yarn prisma generate
+
 # Build the Next.js application.
-RUN yarn build
+RUN yarn build --no-lint
 
 # Expose the port the app runs on.
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,71 @@
-# Use the official Node.js image.
-FROM node:20
+# https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
+FROM node:18-alpine AS base
 
-# Set the working directory inside the container.
+# Install dependencies only when needed
+FROM base AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Copy the package.json and yarn.lock files.
-COPY package.json yarn.lock* ./
+# Install dependencies based on the preferred package manager
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+RUN \
+  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
 
-# Install dependencies.
-RUN yarn install --frozen-lockfile
 
-# Copy the rest of the application code.
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Generate Prisma client
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry during the build.
+# ENV NEXT_TELEMETRY_DISABLED=1
+
 RUN yarn prisma generate
 
-# Build the Next.js application.
-RUN yarn build --no-lint
+RUN \
+  if [ -f yarn.lock ]; then yarn run build; \
+  elif [ -f package-lock.json ]; then npm run build; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
 
-# Expose the port the app runs on.
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+# Uncomment the following line in case you want to disable telemetry during runtime.
+# ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+
+# Set the correct permission for prerender cache
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
 EXPOSE 3000
 
-# Define the command to run the app.
-CMD ["yarn", "start"]
+ENV PORT=3000
+
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/next-config-js/output
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ COPY package*.json ./
 # Install dependencies.
 RUN yarn install
 
+RUN apk add --no-cache python3 make g++ gcc
+
+
 # Copy the rest of the application code.
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use the official Node.js image.
+FROM node:18-alpine
+
+# Set the working directory inside the container.
+WORKDIR /app
+
+# Copy the package.json and yarn.lock files.
+COPY package*.json ./
+
+# Install dependencies.
+RUN yarn install
+
+# Copy the rest of the application code.
+COPY . .
+
+# Build the Next.js application.
+RUN yarn build
+
+# Expose the port the app runs on.
+EXPOSE 3000
+
+# Define the command to run the app.
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,34 @@
 # Opencast
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/s9rLIi?referralCode=y46sre)
-
 A fully open source Twitter flavoured Farcaster client. Originally a fork of [ccrsxx/twitter-clone](https://github.com/ccrsxx/twitter-clone).
 
-The goal of this project is to provide a reference implementation of a Farcaster client in order to make it easier for developers to explore their ideas without having to start from scratch.
+The goal of this project is to be a fully standalone Farcaster client that you can run on your own machine. It only depends on [stephancill/lazy-indexer](https://github.com/stephancill/lazy-indexer) and a connection to a Farcaster Hub.
 
-It only depends on the reference Farcaster postgres indexer and optionally a hub for submitting messages.
+## Running it yourself
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/engine/install/)
+
+1. Clone the repo
+
+```
+git clone git@github.com:stephancill/opencast.git
+```
+
+2. Copy .env.sample, rename it to .env and fill in the values
+
+```
+cp .env.sample .env
+```
+
+3. Run the Docker Compose file
+
+```
+docker-compose up -d
+```
+
+4. Go to Opencast at http://localhost:3000 and log in. It will take a few moments to index your profile and might require you to refresh the page.
 
 ## Development
 
@@ -16,11 +38,23 @@ This project depends on the Lazy Farcaster Indexer. Follow the instructions at [
 
 ### Local
 
-1. `yarn`
+Install dependencies
 
-1. Copy the `.env.sample` file to `.env` and fill in the database connection details.
+```
+yarn install
+```
 
-1. `yarn dev`
+Fill in the environment variables
+
+```
+cp .env.dev.sample .env
+```
+
+Run the development server
+
+```
+yarn dev
+```
 
 ## Todo
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,57 @@
 version: '3.8'
 services:
-  # Postgres service for the indexer
+  # Opencast service
+  opencast:
+    build: ./ # Update to point to the Opencast path
+    container_name: opencast
+    restart: unless-stopped
+    env_file:
+      # Set in .env
+      # APP_FID
+      # APP_MNENOMIC
+      - .env
+    environment:
+      DATABASE_URL: postgresql://indexer:password@postgres:5432/indexer
+      FC_HUB_URL: 'hub-grpc.pinata.cloud'
+      FC_HUB_USE_TLS: 'true'
+      NEXT_PUBLIC_FC_CLIENT_NAME: 'Opencast'
+      NEXT_PUBLIC_WALLETCONNECT_ID: '0fcda49e9f4acad4b84401373fbc5a4f'
+      NEXT_PUBLIC_URL: 'http://localhost:3000'
+      INDEXER_API_URL: 'http://localhost:3005'
+    ports:
+      - '3000:3000'
+    depends_on:
+      - lazy-indexer
+    networks:
+      - app-network
+
+  # Lazy Indexer service
+  lazy-indexer:
+    image: stephancill/lazy-indexer
+    container_name: lazy-indexer
+    env_file:
+      # Set in .env
+      # TARGET_SIGNER_FID=18821 (usually same as APP_FID)
+      - .env
+    environment:
+      DATABASE_URL: postgresql://indexer:password@postgres:5432/indexer
+      REDIS_URL: redis://redis:6379
+      HUB_REST_URL: https://hub.pinata.cloud
+      HUB_RPC: hub-grpc.pinata.cloud
+      HUB_SSL: true
+      WORKER_CONCURRENCY: 5
+      LOG_LEVEL: debug
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - '3005:3005'
+    networks:
+      - app-network
+
+    # Postgres service for the indexer
   postgres:
     image: 'postgres:16-alpine'
     restart: unless-stopped
@@ -14,10 +65,10 @@ services:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB']
-      interval: 5s       # Check every 5 seconds for readiness
-      timeout: 5s        # Allow up to 5 seconds for a response
-      retries: 3         # Fail after 3 unsuccessful attempts
-      start_period: 10s  # Start checks after 10 seconds
+      interval: 5s # Check every 5 seconds for readiness
+      timeout: 5s # Allow up to 5 seconds for a response
+      retries: 3 # Fail after 3 unsuccessful attempts
+      start_period: 10s # Start checks after 10 seconds
     networks:
       - app-network
 
@@ -31,55 +82,10 @@ services:
       - '6379:6379'
     healthcheck:
       test: ['CMD-SHELL', 'redis-cli ping']
-      interval: 5s       # Check every 5 seconds
-      timeout: 5s        # Allow up to 5 seconds for a response
-      retries: 3         # Fail after 3 unsuccessful attempts
-      start_period: 5s   # Start health checks after 5 seconds
-    networks:
-      - app-network
-
-  # Lazy Indexer service
-  lazy-indexer:
-    image: stephancill/lazy-indexer
-    container_name: lazy-indexer
-    environment:
-      DATABASE_URL: postgresql://indexer:password@postgres:5432/indexer
-      REDIS_URL: redis://redis:6379
-      HUB_REST_URL: https://hub.pinata.cloud
-      HUB_RPC: hub-grpc.pinata.cloud
-      HUB_SSL: "true"
-      WORKER_CONCURRENCY: 5
-      LOG_LEVEL: debug
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    networks:
-      - app-network
-
-  # Opencast service
-  opencast:
-    build: ./ # Update to point to the Opencast path
-    container_name: opencast
-    restart: unless-stopped
-    env_file:
-      # Set in .env
-      # APP_FID
-      # APP_MNENOMIC
-      - .env
-    environment:
-      DATABASE_URL: postgresql://indexer:password@postgres:5432/indexer
-      FC_HUB_URL: "hub-grpc.pinata.cloud"
-      FC_HUB_USE_TLS: "true"
-      NEXT_PUBLIC_FC_CLIENT_NAME: "Opencast"
-      NEXT_PUBLIC_WALLETCONNECT_ID: "0fcda49e9f4acad4b84401373fbc5a4f"
-      NEXT_PUBLIC_URL: "http://localhost:3000"
-      INDEXER_API_URL: "http://localhost:3005"
-    ports:
-      - "3000:3000"
-    depends_on:
-      - lazy-indexer
+      interval: 5s # Check every 5 seconds
+      timeout: 5s # Allow up to 5 seconds for a response
+      retries: 3 # Fail after 3 unsuccessful attempts
+      start_period: 5s # Start health checks after 5 seconds
     networks:
       - app-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,51 +1,80 @@
 version: '3.8'
-
 services:
-  lazy-indexer:
-    image: gabrieltemtsen/lazy-indexer:latest  # Use the published image from Docker Hub
+  # Postgres service for the indexer
+  postgres:
+    image: postgres:13
+    container_name: lazy-indexer-postgres
     environment:
-      - HUB_REST_URL=https://hub.pinata.cloud
-      - HUB_RPC=hub-grpc.pinata.cloud
-      - HUB_SSL=true
-      - DATABASE_URL="postgresql://indexer:password@localhost:5432/indexer"
-      - REDIS_URL=redis://redis:6379
-      - WORKER_CONCURRENCY=5
-      - LOG_LEVEL=debug
-    depends_on:
-      - db
-      - redis
+      POSTGRES_USER: indexer
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: indexer
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "indexer"]
+      interval: 10s
+      retries: 5
     networks:
       - app-network
 
-  opencast:
-    build:
-      context: . 
-    environment:
-      - DATABASE_URL="postgres://replicator:password@localhost:6541/replicator?schema=public"
-    ports:
-      - "3000:3000"  # Maps port 3000 on the host to port 3000 in the container
-    depends_on:
-      - db
-    networks:
-      - app-network
-
-  db:
-    image: postgres:15
-    environment:
-      - POSTGRES_USER=indexer
-      - POSTGRES_PASSWORD=password
-      - POSTGRES_DB=indexer
-    ports:
-      - "5432:5432"
-    networks:
-      - app-network
-
+  # Redis service for caching (if used by the indexer or opencast)
   redis:
     image: redis:alpine
-    ports:
-      - "6379:6379"
+    container_name: lazy-indexer-redis
+    command: --loglevel warning --maxmemory-policy noeviction
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      retries: 5
     networks:
       - app-network
+
+  # Lazy Indexer service
+  lazy-indexer:
+    image: gabrieltemtsen/lazy-indexer # Update to point to the Lazy Indexer  image
+    container_name: lazy-indexer
+    environment:
+      DATABASE_URL: postgresql://indexer:password@postgres:5432/indexer
+      REDIS_URL: redis://redis:6379
+      HUB_REST_URL: https://hub.pinata.cloud
+      HUB_RPC: hub-grpc.pinata.cloud
+      HUB_SSL: "true"
+      WORKER_CONCURRENCY: 5
+      LOG_LEVEL: debug
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - app-network
+
+  # Opencast service
+  opencast:
+    build: ./ # Update to point to the Opencast Dockerfile path
+    container_name: opencast
+    environment:
+      DATABASE_URL: postgresql://indexer:password@postgres:5432/indexer
+      FC_HUB_URL: localhost:2283
+      FC_HUB_USE_TLS: "false"
+      APP_FID: 1
+      APP_MNENOMIC: ""
+      NEXT_PUBLIC_FC_CLIENT_NAME: "Opencast"
+      NEXT_PUBLIC_WALLETCONNECT_ID: "0fcda49e9f4acad4b84401373fbc5a4f"
+      NEXT_PUBLIC_URL: "http://localhost:3000"
+      INDEXER_API_URL: "http://localhost:3005"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - lazy-indexer
+    networks:
+      - app-network
+
+volumes:
+  postgres-data:
+  redis-data:
 
 networks:
   app-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,31 +2,39 @@ version: '3.8'
 services:
   # Postgres service for the indexer
   postgres:
-    image: postgres:13
-    container_name: lazy-indexer-postgres
+    image: 'postgres:16-alpine'
+    restart: unless-stopped
+    ports:
+      - '5432:5432'
     environment:
-      POSTGRES_USER: indexer
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: indexer
+      - POSTGRES_DB=indexer
+      - POSTGRES_USER=indexer
+      - POSTGRES_PASSWORD=password
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "indexer"]
-      interval: 10s
-      retries: 5
+      test: ['CMD-SHELL', 'pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB']
+      interval: 5s       # Check every 5 seconds for readiness
+      timeout: 5s        # Allow up to 5 seconds for a response
+      retries: 3         # Fail after 3 unsuccessful attempts
+      start_period: 10s  # Start checks after 10 seconds
     networks:
       - app-network
 
   redis:
-    image: redis:alpine
-    container_name: lazy-indexer-redis
+    image: 'redis:7.2-alpine'
+    restart: unless-stopped
     command: --loglevel warning --maxmemory-policy noeviction
     volumes:
       - redis-data:/data
+    ports:
+      - '6379:6379'
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      retries: 5
+      test: ['CMD-SHELL', 'redis-cli ping']
+      interval: 5s       # Check every 5 seconds
+      timeout: 5s        # Allow up to 5 seconds for a response
+      retries: 3         # Fail after 3 unsuccessful attempts
+      start_period: 5s   # Start health checks after 5 seconds
     networks:
       - app-network
 
@@ -54,6 +62,7 @@ services:
   opencast:
     build: ./ # Update to point to the Opencast path
     container_name: opencast
+    restart: unless-stopped
     env_file:
       # Set in .env
       # APP_FID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,52 @@
 version: '3.8'
+
 services:
-  dev-db:
-    image: postgres:13
-    ports:
-      - 5432:5432
+  lazy-indexer:
+    image: gabrieltemtsen/lazy-indexer:latest  # Use the published image from Docker Hub
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: admin
-      POSTGRES_DB: postgres
+      - HUB_REST_URL=https://hub.pinata.cloud
+      - HUB_RPC=hub-grpc.pinata.cloud
+      - HUB_SSL=true
+      - DATABASE_URL="postgresql://indexer:password@localhost:5432/indexer"
+      - REDIS_URL=redis://redis:6379
+      - WORKER_CONCURRENCY=5
+      - LOG_LEVEL=debug
+    depends_on:
+      - db
+      - redis
     networks:
-      - main
+      - app-network
+
+  opencast:
+    build:
+      context: . 
+    environment:
+      - DATABASE_URL="postgres://replicator:password@localhost:6541/replicator?schema=public"
+    ports:
+      - "3000:3000"  # Maps port 3000 on the host to port 3000 in the container
+    depends_on:
+      - db
+    networks:
+      - app-network
+
+  db:
+    image: postgres:15
+    environment:
+      - POSTGRES_USER=indexer
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=indexer
+    ports:
+      - "5432:5432"
+    networks:
+      - app-network
+
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+    networks:
+      - app-network
 
 networks:
-  main:
+  app-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     networks:
       - app-network
 
-  # Redis service for caching (if used by the indexer or opencast)
   redis:
     image: redis:alpine
     container_name: lazy-indexer-redis
@@ -53,7 +52,7 @@ services:
 
   # Opencast service
   opencast:
-    build: ./ # Update to point to the Opencast Dockerfile path
+    build: ./ # Update to point to the Opencast path
     container_name: opencast
     environment:
       DATABASE_URL: postgresql://indexer:password@postgres:5432/indexer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
 
   # Lazy Indexer service
   lazy-indexer:
-    image: gabrieltemtsen/lazy-indexer # Update to point to the Lazy Indexer  image
+    image: stephancill/lazy-indexer
     container_name: lazy-indexer
     environment:
       DATABASE_URL: postgresql://indexer:password@postgres:5432/indexer
@@ -54,12 +54,15 @@ services:
   opencast:
     build: ./ # Update to point to the Opencast path
     container_name: opencast
+    env_file:
+      # Set in .env
+      # APP_FID
+      # APP_MNENOMIC
+      - .env
     environment:
       DATABASE_URL: postgresql://indexer:password@postgres:5432/indexer
-      FC_HUB_URL: localhost:2283
-      FC_HUB_USE_TLS: "false"
-      APP_FID: 1
-      APP_MNENOMIC: ""
+      FC_HUB_URL: "hub-grpc.pinata.cloud"
+      FC_HUB_USE_TLS: "true"
       NEXT_PUBLIC_FC_CLIENT_NAME: "Opencast"
       NEXT_PUBLIC_WALLETCONNECT_ID: "0fcda49e9f4acad4b84401373fbc5a4f"
       NEXT_PUBLIC_URL: "http://localhost:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 version: '3.8'
 services:
-  # Opencast service
   opencast:
-    build: ./ # Update to point to the Opencast path
+    build: ./
     container_name: opencast
     restart: unless-stopped
     env_file:
@@ -17,7 +16,7 @@ services:
       NEXT_PUBLIC_FC_CLIENT_NAME: 'Opencast'
       NEXT_PUBLIC_WALLETCONNECT_ID: '0fcda49e9f4acad4b84401373fbc5a4f'
       NEXT_PUBLIC_URL: 'http://localhost:3000'
-      INDEXER_API_URL: 'http://localhost:3005'
+      INDEXER_API_URL: 'http://lazy-indexer:3005'
     ports:
       - '3000:3000'
     depends_on:
@@ -25,13 +24,12 @@ services:
     networks:
       - app-network
 
-  # Lazy Indexer service
   lazy-indexer:
     image: stephancill/lazy-indexer
     container_name: lazy-indexer
     env_file:
       # Set in .env
-      # TARGET_SIGNER_FID=18821 (usually same as APP_FID)
+      # TARGET_SIGNER_FID (usually same as APP_FID)
       - .env
     environment:
       DATABASE_URL: postgresql://indexer:password@postgres:5432/indexer
@@ -51,7 +49,6 @@ services:
     networks:
       - app-network
 
-    # Postgres service for the indexer
   postgres:
     image: 'postgres:16-alpine'
     restart: unless-stopped

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  output: "standalone",
   webpack: (config) => {
     config.resolve.fallback = { fs: false, net: false, tls: false };
     return config;


### PR DESCRIPTION
The PR adds a docker-compose.yml configuration to simplify the process of setting up and running both the Lazy Indexer and Opencast services in Docker containers:

- Added a docker-compose.yml file to set up and run the Lazy Indexer and Opencast using Docker.
- Created a Docker image for the Lazy Indexer and published it to Docker Hub as 'gabrieltemtsen/lazy-indexer:latest'.
- Configured the services to use PostgreSQL and Redis with the appropriate environment settings(from the env samples).